### PR TITLE
fix(llm): omit incompatible generation parameters

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -207,7 +207,6 @@ class LLMInvokeHandler {
           userPrompt: payload.userPrompt,
           responseFormat: payload.responseFormat === 'text' ? 'text' : 'json',
           maxTokens: typeof payload.maxTokens === 'number' ? payload.maxTokens : 1024,
-          temperature: typeof payload.temperature === 'number' ? payload.temperature : 0,
         },
         storedSettings
       );

--- a/src/services/ai.ts
+++ b/src/services/ai.ts
@@ -30,7 +30,6 @@ export class AIService {
       userPrompt,
       responseFormat,
       maxTokens,
-      temperature: 0,
     };
 
     const response = (await chrome.runtime.sendMessage({

--- a/src/services/llm/providers.test.ts
+++ b/src/services/llm/providers.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { buildOpenAICompatibleRequest } from './providers';
+import type { LLMInvokePayload } from './types';
+
+const payload: LLMInvokePayload = {
+  systemPrompt: 'system prompt',
+  userPrompt: 'user prompt',
+  responseFormat: 'text',
+  maxTokens: 512,
+  temperature: 0.7,
+};
+
+describe('buildOpenAICompatibleRequest', () => {
+  it('uses GPT-5-compatible parameters for GPT-5 models', () => {
+    const request = buildOpenAICompatibleRequest(payload, ' gpt-5.6-luna ');
+
+    expect(request).toMatchObject({
+      model: ' gpt-5.6-luna ',
+      max_completion_tokens: 512,
+    });
+    expect(request).not.toHaveProperty('max_tokens');
+    expect(request).not.toHaveProperty('temperature');
+  });
+
+  it('keeps legacy parameters for non-GPT-5 models', () => {
+    const request = buildOpenAICompatibleRequest(payload, 'gpt-4.1');
+
+    expect(request).toMatchObject({
+      model: 'gpt-4.1',
+      max_tokens: 512,
+      temperature: 0.7,
+    });
+    expect(request).not.toHaveProperty('max_completion_tokens');
+  });
+
+  it('omits temperature for Kimi models', () => {
+    const request = buildOpenAICompatibleRequest(payload, 'kimi-k2');
+
+    expect(request).toMatchObject({
+      max_tokens: 512,
+    });
+    expect(request).not.toHaveProperty('temperature');
+  });
+});

--- a/src/services/llm/providers.test.ts
+++ b/src/services/llm/providers.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from 'vitest';
-import { buildOpenAICompatibleRequest } from './providers';
+import { describe, expect, it, vi } from 'vitest';
+
+const anthropicCreate = vi.hoisted(() => vi.fn());
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class Anthropic {
+    messages = { create: anthropicCreate };
+  },
+}));
+
+import { buildOpenAICompatibleRequest, LLMGateway } from './providers';
 import type { LLMInvokePayload } from './types';
 
 const payload: LLMInvokePayload = {
@@ -7,38 +16,66 @@ const payload: LLMInvokePayload = {
   userPrompt: 'user prompt',
   responseFormat: 'text',
   maxTokens: 512,
-  temperature: 0.7,
 };
 
 describe('buildOpenAICompatibleRequest', () => {
-  it('uses GPT-5-compatible parameters for GPT-5 models', () => {
-    const request = buildOpenAICompatibleRequest(payload, ' gpt-5.6-luna ');
-
-    expect(request).toMatchObject({
-      model: ' gpt-5.6-luna ',
-      max_completion_tokens: 512,
+  it.each(['gpt-5.6-luna', 'gpt-4.1', 'kimi-k2'])('omits optional parameters for %s', (model) => {
+    expect(buildOpenAICompatibleRequest(payload, model)).toEqual({
+      model,
+      messages: [
+        { role: 'system', content: 'system prompt' },
+        { role: 'user', content: 'user prompt' },
+      ],
     });
-    expect(request).not.toHaveProperty('max_tokens');
-    expect(request).not.toHaveProperty('temperature');
   });
 
-  it('keeps legacy parameters for non-GPT-5 models', () => {
-    const request = buildOpenAICompatibleRequest(payload, 'gpt-4.1');
-
-    expect(request).toMatchObject({
-      model: 'gpt-4.1',
-      max_tokens: 512,
-      temperature: 0.7,
+  it('omits temperature from Anthropic Messages requests', async () => {
+    anthropicCreate.mockResolvedValue({
+      id: 'message-1',
+      content: [{ type: 'text', text: 'response' }],
     });
-    expect(request).not.toHaveProperty('max_completion_tokens');
+
+    await LLMGateway.invoke(payload, {
+      provider: 'anthropic',
+      baseUrl: 'https://api.anthropic.com',
+      apiKey: 'test-key',
+      model: 'claude-opus-4-6',
+    });
+
+    expect(anthropicCreate).toHaveBeenCalledWith({
+      model: 'claude-opus-4-6',
+      max_tokens: 512,
+      system: 'system prompt',
+      messages: [{ role: 'user', content: 'user prompt' }],
+    });
   });
 
-  it('omits temperature for Kimi models', () => {
-    const request = buildOpenAICompatibleRequest(payload, 'kimi-k2');
-
-    expect(request).toMatchObject({
-      max_tokens: 512,
+  it('omits temperature from native custom fetch requests', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ message: { content: 'response' } }),
     });
-    expect(request).not.toHaveProperty('temperature');
+    vi.stubGlobal('fetch', fetchMock);
+
+    try {
+      await LLMGateway.invoke(payload, {
+        provider: 'custom_fetch',
+        baseUrl: 'http://localhost:11434',
+        apiKey: '',
+        model: 'local-model',
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    const [, options] = fetchMock.mock.calls[0];
+    expect(JSON.parse(options.body)).toEqual({
+      model: 'local-model',
+      messages: [
+        { role: 'system', content: 'system prompt' },
+        { role: 'user', content: 'user prompt' },
+      ],
+      stream: false,
+    });
   });
 });

--- a/src/services/llm/providers.ts
+++ b/src/services/llm/providers.ts
@@ -12,42 +12,19 @@ import {
 type OpenAICompatibleRequest = {
   model: string;
   messages: Array<{ role: 'system' | 'user'; content: string }>;
-  max_tokens?: number;
-  max_completion_tokens?: number;
-  temperature?: number;
 };
 
 export function buildOpenAICompatibleRequest(
   payload: LLMInvokePayload,
   model: string
 ): OpenAICompatibleRequest {
-  const request: OpenAICompatibleRequest = {
+  return {
     model,
     messages: [
       { role: 'system', content: payload.systemPrompt },
       { role: 'user', content: payload.userPrompt },
     ],
   };
-
-  if (usesGPT5Parameters(model)) {
-    request.max_completion_tokens = payload.maxTokens;
-  } else {
-    request.max_tokens = payload.maxTokens;
-
-    if (!usesLockedKimiTemperature(model)) {
-      request.temperature = payload.temperature;
-    }
-  }
-
-  return request;
-}
-
-function usesGPT5Parameters(model: string): boolean {
-  return /^gpt-5/i.test(model.trim());
-}
-
-function usesLockedKimiTemperature(model: string): boolean {
-  return model.trim().toLowerCase().includes('kimi');
 }
 
 export class LLMGateway {
@@ -122,7 +99,6 @@ export class LLMGateway {
     const message = await client.messages.create({
       model: settings.model,
       max_tokens: payload.maxTokens,
-      temperature: payload.temperature,
       system: payload.systemPrompt,
       messages: [
         {
@@ -180,7 +156,6 @@ export class LLMGateway {
                 { role: 'system', content: payload.systemPrompt },
                 { role: 'user', content: payload.userPrompt },
               ],
-              temperature: payload.temperature,
               stream: false,
             }
       ),

--- a/src/services/llm/providers.ts
+++ b/src/services/llm/providers.ts
@@ -12,7 +12,8 @@ import {
 type OpenAICompatibleRequest = {
   model: string;
   messages: Array<{ role: 'system' | 'user'; content: string }>;
-  max_tokens: number;
+  max_tokens?: number;
+  max_completion_tokens?: number;
   temperature?: number;
 };
 
@@ -26,14 +27,23 @@ export function buildOpenAICompatibleRequest(
       { role: 'system', content: payload.systemPrompt },
       { role: 'user', content: payload.userPrompt },
     ],
-    max_tokens: payload.maxTokens,
   };
 
-  if (!usesLockedKimiTemperature(model)) {
-    request.temperature = payload.temperature;
+  if (usesGPT5Parameters(model)) {
+    request.max_completion_tokens = payload.maxTokens;
+  } else {
+    request.max_tokens = payload.maxTokens;
+
+    if (!usesLockedKimiTemperature(model)) {
+      request.temperature = payload.temperature;
+    }
   }
 
   return request;
+}
+
+function usesGPT5Parameters(model: string): boolean {
+  return /^gpt-5/i.test(model.trim());
 }
 
 function usesLockedKimiTemperature(model: string): boolean {

--- a/src/services/llm/types.ts
+++ b/src/services/llm/types.ts
@@ -7,7 +7,6 @@ export interface LLMInvokePayload {
   userPrompt: string;
   responseFormat: LLMResponseFormat;
   maxTokens: number;
-  temperature: number;
 }
 
 export interface LLMInvokeResult {


### PR DESCRIPTION
## Summary

- OpenAI 兼容请求仅发送模型和消息。
- 所有 LLM 调用路径均省略 temperature。
- Anthropic 请求保留必填的 max_tokens。
- 新增三条调用路径的请求参数回归测试。

## Motivation

修复 GPT-5 调用失败问题，并避免新版模型因可选生成参数不兼容而拒绝请求。

## Changes

- src/services/llm/providers.ts 移除 OpenAI 兼容请求中的 max_tokens、max_completion_tokens 和 temperature。
- src/services/llm/providers.ts 移除 Anthropic 与原生自定义 fetch 请求中的 temperature。
- src/services/llm/types.ts、src/services/ai.ts 和 src/background.ts 移除不再使用的 temperature 负载字段。

## Testing

- [x] npm test -- --run
- [x] npm run build

## Risk

- Medium risk. OpenAI 兼容服务使用服务端默认输出长度，应用不再传递输出上限。
- Low risk. temperature 使用各服务的默认采样策略。

## Notes

Fixes #42